### PR TITLE
Updated PNG image handling and Skipping Image  Sizing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cordova-plugin-camera",
-  "version": "8.0.0",
+  "version": "8.0.1-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cordova-plugin-camera",
-      "version": "8.0.0",
+      "version": "8.0.1-dev",
       "license": "Apache-2.0",
       "devDependencies": {
         "@cordova/eslint-config": "^5.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-camera",
-  "version": "8.0.0",
+  "version": "8.0.1-dev",
   "description": "Cordova Camera Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-camera"
-    version="8.0.0">
+    version="8.0.1-dev">
     <name>Camera</name>
     <description>Cordova Camera Plugin</description>
     <license>Apache 2.0</license>

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -111,7 +111,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
     //Where did this come from?
     private static final int CROP_CAMERA = 100;
-    private long IMAGE_SIZE_LIMIT = (20 * 1024 * 1024);
+    private long imageSizeLimit;
 
     private static final String TIME_FORMAT = "yyyyMMdd_HHmmss";
 
@@ -173,7 +173,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
             this.allowEdit = args.getBoolean(7);
             this.correctOrientation = args.getBoolean(8);
             this.saveToPhotoAlbum = args.getBoolean(9);
-            this.IMAGE_SIZE_LIMIT = args.getLong(12) * 1024 * 1024;
+            this.imageSizeLimit = args.get(12).toString().equals("null") || args.getLong(12) <= 0 ? 0 : args.getLong(12) * 1024 * 1024;
 
             // If the user specifies a 0 or smaller width/height
             // make it -1 so later comparisons succeed
@@ -759,14 +759,16 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
     private void processResultFromGallery(int destType, Intent intent) {
         Uri uri = intent.getData();
 
-        long imageSize = getImageSize(uri);
-        if(imageSize == -1){
-            this.failPicture("Unable to retrieve Image Properties for provided URL");
-            return;
-        }
-        if(imageSize > IMAGE_SIZE_LIMIT){
-            this.failPicture(IMAGE_SIZE_EXCEEDED_ERROR);
-            return;
+       if(imageSizeLimit > 0) {
+            long imageSize = getImageSize(uri);
+            if (imageSize == -1) {
+                this.failPicture("Unable to retrieve Image Properties");
+                return;
+            }
+            if (imageSize > imageSizeLimit) {
+                this.failPicture(IMAGE_SIZE_EXCEEDED_ERROR);
+                return;
+            }
         }
 
         if (uri == null) {

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -99,6 +99,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
     private static final String GET_All = "Get All";
     private static final String CROPPED_URI_KEY = "croppedUri";
     private static final String IMAGE_URI_KEY = "imageUri";
+    private static final String IMAGE_SIZE_EXCEEDED_ERROR = "PHOTO_SIZE_EXCEEDS_THE_ALLOWED_LIMIT";
 
     private static final String TAKE_PICTURE_ACTION = "takePicture";
 
@@ -764,7 +765,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
             return;
         }
         if(imageSize > IMAGE_SIZE_LIMIT){
-            this.failPicture("Photo Exceeds the limit");
+            this.failPicture(IMAGE_SIZE_EXCEEDED_ERROR);
             return;
         }
 

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -110,7 +110,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
     //Where did this come from?
     private static final int CROP_CAMERA = 100;
-    private static final int IMAGE_SIZE_LIMIT = (20 * 1024 * 1024);
+    private long IMAGE_SIZE_LIMIT = (20 * 1024 * 1024);
 
     private static final String TIME_FORMAT = "yyyyMMdd_HHmmss";
 
@@ -172,6 +172,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
             this.allowEdit = args.getBoolean(7);
             this.correctOrientation = args.getBoolean(8);
             this.saveToPhotoAlbum = args.getBoolean(9);
+            this.IMAGE_SIZE_LIMIT = args.getLong(12) * 1024 * 1024;
 
             // If the user specifies a 0 or smaller width/height
             // make it -1 so later comparisons succeed
@@ -722,6 +723,15 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         return this.encodingType == JPEG ? JPEG_EXTENSION : PNG_EXTENSION;
     }
 
+    /**
+   * Retrieves the size of the image (or file) pointed to by the given URI.
+   *
+   * <p>This method uses the ContentResolver to query metadata about the file,
+   *
+   * @param uri The {@link android.net.Uri} pointing to the image or file.
+   * @return The size of the file in bytes, or -1 if the size could not be determined
+   *         (e.g., the URI is null, the size column is not available, or an error occurs).
+   */
      private long getImageSize(Uri uri) {
         if (uri == null) return -1;
 

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -1055,8 +1055,9 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                     LOG.d(LOG_TAG, "Exception while closing file input stream.");
                 }
             }
-            if (this.targetWidth <= 0 && this.targetHeight <= 0 && !(this.correctOrientation) || ((image!=null && image.getWidth() <= this.targetWidth && image.getHeight() <= this.targetHeight)))
+            if (this.targetWidth <= 0 && this.targetHeight <= 0 && !(this.correctOrientation) || ((image!=null && image.getWidth() <= this.targetWidth && image.getHeight() <= this.targetHeight))){
                     return image;
+            }
         }
 
         int rotate = 0;

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -39,6 +39,7 @@
 
 static NSSet* org_apache_cordova_validArrowDirections;
 NSUInteger IMAGE_SIZE_LIMIT= (20 * 1024 * 1024);
+static const NSString * IMAGE_SIZE_EXCEEDED_ERROR = @"PHOTO_SIZE_EXCEEDS_THE_ALLOWED_LIMIT";
 
 static NSString* toBase64(NSData* data) {
     SEL s1 = NSSelectorFromString(@"cdv_base64EncodedString");
@@ -718,7 +719,7 @@ static NSString* MIME_JPEG    = @"image/jpeg";
                           completionHandler:^(NSError *error) {
                               if (imageSize > imageSizeLimit) {
                                   dispatch_async(dispatch_get_main_queue(), ^{
-                                                                    CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Photo Exceeds the limit"];
+                                                                    CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:IMAGE_SIZE_EXCEEDED_ERROR];
                                                                     [self.commandDelegate sendPluginResult:result callbackId:self.pickerController.callbackId];
                                                                     [self.viewController dismissViewControllerAnimated:YES completion:nil];
                                                                 });

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -38,7 +38,7 @@
 #define CDV_PHOTO_PREFIX @"cdv_photo_"
 
 static NSSet* org_apache_cordova_validArrowDirections;
-NSUInteger IMAGE_SIZE_LIMIT= (20 * 1024 * 1024);
+NSUInteger imageSizeLimit;
 static const NSString * IMAGE_SIZE_EXCEEDED_ERROR = @"PHOTO_SIZE_EXCEEDS_THE_ALLOWED_LIMIT";
 
 static NSString* toBase64(NSData* data) {
@@ -90,7 +90,9 @@ static NSString* MIME_JPEG    = @"image/jpeg";
 
     pictureOptions.popoverSupported = NO;
     pictureOptions.usesGeolocation = NO;
-    IMAGE_SIZE_LIMIT = [[command argumentAtIndex:12]longValue] * 1024 * 1024;
+    id sizeLimitArg = [command argumentAtIndex:12];
+    imageSizeLimit = (sizeLimitArg == [NSNull null] || [sizeLimitArg longValue] <= 0) ? 0 : [sizeLimitArg longValue] * 1024 * 1024;
+
 
     return pictureOptions;
 }
@@ -702,7 +704,7 @@ static NSString* MIME_JPEG    = @"image/jpeg";
 
 - (void)imagePickerController:(UIImagePickerController*)picker didFinishPickingMediaWithInfo:(NSDictionary*)info
 {
-
+  if(imageSizeLimit > 0){
     PHAsset *phAsset = [info objectForKey:UIImagePickerControllerPHAsset];
     if (phAsset) {
         NSArray *resources = [PHAssetResource assetResourcesForAsset:phAsset];
@@ -727,6 +729,7 @@ static NSString* MIME_JPEG    = @"image/jpeg";
                               }
                         }];
       }
+  }
     __weak CDVCameraPicker* cameraPicker = (CDVCameraPicker*)picker;
     __weak CDVCamera* weakSelf = self;
 

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -38,7 +38,7 @@
 #define CDV_PHOTO_PREFIX @"cdv_photo_"
 
 static NSSet* org_apache_cordova_validArrowDirections;
-static const NSUInteger IMAGE_SIZE_LIMIT= (20 * 1024 * 1024);
+NSUInteger IMAGE_SIZE_LIMIT= (20 * 1024 * 1024);
 
 static NSString* toBase64(NSData* data) {
     SEL s1 = NSSelectorFromString(@"cdv_base64EncodedString");
@@ -89,6 +89,7 @@ static NSString* MIME_JPEG    = @"image/jpeg";
 
     pictureOptions.popoverSupported = NO;
     pictureOptions.usesGeolocation = NO;
+    IMAGE_SIZE_LIMIT = [[command argumentAtIndex:12]longValue] * 1024 * 1024;
 
     return pictureOptions;
 }

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -304,7 +304,7 @@ static NSString* MIME_JPEG    = @"image/jpeg";
 - (void)navigationController:(UINavigationController *)navigationController willShowViewController:(UIViewController *)viewController animated:(BOOL)animated
 {
     if([navigationController isKindOfClass:[UIImagePickerController class]]){
-        
+
         // If popoverWidth and popoverHeight are specified and are greater than 0, then set popover size, else use apple's default popoverSize
         NSDictionary* options = self.pickerController.pictureOptions.popoverOptions;
         if(options) {
@@ -315,8 +315,8 @@ static NSString* MIME_JPEG    = @"image/jpeg";
                 [viewController setPreferredContentSize:CGSizeMake(popoverWidth,popoverHeight)];
             }
         }
-        
-        
+
+
         UIImagePickerController* cameraPicker = (UIImagePickerController*)navigationController;
 
         if(![cameraPicker.mediaTypes containsObject:(NSString*)kUTTypeImage]){
@@ -386,11 +386,11 @@ static NSString* MIME_JPEG    = @"image/jpeg";
 
 - (NSString*) formatAsDataURI:(NSData*) data withMIME:(NSString*) mime {
     NSString* base64 = toBase64(data);
-    
+
     if (base64 == nil) {
         return nil;
     }
-    
+
     return [NSString stringWithFormat:@"data:%@;base64,%@", mime, base64];
 }
 
@@ -398,7 +398,7 @@ static NSString* MIME_JPEG    = @"image/jpeg";
 {
     NSString* mime = nil;
     NSData* data = [self processImage: image info: info options: options outMime: &mime];
-    
+
     return [self formatAsDataURI: data withMIME: mime];
 }
 
@@ -476,8 +476,8 @@ static NSString* MIME_JPEG    = @"image/jpeg";
         default:
             break;
     };
-    
-    
+
+
     return data;
 }
 
@@ -581,6 +581,11 @@ static NSString* MIME_JPEG    = @"image/jpeg";
     UIImage* scaledImage = nil;
 
     if ((options.targetSize.width > 0) && (options.targetSize.height > 0)) {
+        CGSize imageSize = image.size;
+        if (imageSize.width <= options.targetSize.width && imageSize.height <= options.targetSize.height) {
+            // Image is already smaller than target size, no need to scale
+            return image;
+        }
         // if cropToSize, resize image and crop to target size, otherwise resize to fit target without cropping
         if (options.cropToSize) {
             scaledImage = [image imageByScalingAndCroppingForSize:options.targetSize];
@@ -612,9 +617,14 @@ static NSString* MIME_JPEG    = @"image/jpeg";
         {
             image = [self retrieveImage:info options:options];
             NSData* data = [self processImage:image info:info options:options];
-            
+
             if (data) {
                 if (pickerController.sourceType == UIImagePickerControllerSourceTypePhotoLibrary) {
+                    NSURL* imageURL = [info objectForKey:UIImagePickerControllerImageURL];
+                    NSString* ext = [[imageURL pathExtension] lowercaseString];
+                    if([ext isEqualToString:@"png"]){
+                       options.encodingType = EncodingTypePNG;
+                    }
                     NSMutableData *imageDataWithExif = [NSMutableData data];
                     if (self.metadata) {
                         CGImageSourceRef sourceImage = CGImageSourceCreateWithData((__bridge CFDataRef)self.data, NULL);
@@ -641,7 +651,7 @@ static NSString* MIME_JPEG    = @"image/jpeg";
                     else {
                         result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:[[self urlTransformer:[NSURL fileURLWithPath:filePath]] absoluteString]];
                     }
-                    
+
                 } else if (pickerController.sourceType != UIImagePickerControllerSourceTypeCamera || !options.usesGeolocation) {
                     // No need to save file if usesGeolocation is true since it will be saved after the location is tracked
                     NSString* extension = options.encodingType == EncodingTypePNG? @"png" : @"jpg";
@@ -840,7 +850,7 @@ static NSString* MIME_JPEG    = @"image/jpeg";
 {
     CDVPictureOptions* options = self.pickerController.pictureOptions;
     CDVPluginResult* result = nil;
-   
+
     NSMutableData *imageDataWithExif = [NSMutableData data];
 
     if (self.metadata) {

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cordova-plugin-camera-tests",
-  "version": "8.0.0",
+  "version": "8.0.1-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cordova-plugin-camera-tests",
-      "version": "8.0.0",
+      "version": "8.0.1-dev",
       "license": "Apache-2.0"
     }
   }

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-camera-tests",
-  "version": "8.0.0",
+  "version": "8.0.1-dev",
   "description": "",
   "cordova": {
     "id": "cordova-plugin-camera-tests",

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -22,7 +22,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     id="cordova-plugin-camera-tests"
-    version="8.0.0">
+    version="8.0.1-dev">
     <name>Cordova Camera Plugin Tests</name>
     <license>Apache 2.0</license>
 

--- a/www/Camera.js
+++ b/www/Camera.js
@@ -142,13 +142,13 @@ cameraExport.getPicture = function (successCallback, errorCallback, options) {
     const saveToPhotoAlbum = !!options.saveToPhotoAlbum;
     const popoverOptions = getValue(options.popoverOptions, null);
     const cameraDirection = getValue(options.cameraDirection, Camera.Direction.BACK);
+    const imageSizeLimit = getValue(options.fileSize);
 
     if (allowEdit) {
         console.warn('allowEdit is deprecated. It does not work reliably on all platforms. Utilise a dedicated image editing library instead. allowEdit functionality is scheduled to be removed in a future release.');
     }
 
-    const args = [quality, destinationType, sourceType, targetWidth, targetHeight, encodingType,
-        mediaType, allowEdit, correctOrientation, saveToPhotoAlbum, popoverOptions, cameraDirection];
+    const args = [quality, destinationType, sourceType, targetWidth, targetHeight, encodingType, mediaType, allowEdit, correctOrientation, saveToPhotoAlbum, popoverOptions, cameraDirection, imageSizeLimit];
 
     exec(successCallback, errorCallback, 'Camera', 'takePicture', args);
     // XXX: commented out


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- Android
- iOS


### Motivation and Context
Previously, PNG images were being converted to JPG during processing. Additionally, image scaling logic did not handle cases where the uploaded image was smaller than the specified width and height, which could result in unnecessary or undesired upscaling.



### Description

- Fixed image processing to retain PNG format instead of converting it to JPG.
- Added check to skip scaling when the original image is smaller than the provided width and height.

### Testing

- Verified image format retention (PNG stays PNG) after processing on both platforms.
- Confirmed that scaling is skipped for smaller images.
- Tested various image types (PNG, JPG) across devices on both Android and iOS.
- Ensured no regressions in other image processing functionalities.



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
