### PR TITLE
Compress image until max

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -714,7 +714,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         }
         // if the picture is not a jpeg or png, (a .heic for example) when processed to a bitmap
         // the file extension is changed to the output format, f.e. an input file my_photo.heic could become my_photo.jpg
-        return fileName.substring(fileName.lastIndexOf(".") + 1) + getExtensionForEncodingType();
+        return fileName.substring(0, fileName.lastIndexOf(".")) + getExtensionForEncodingType();
     }
 
     private String getExtensionForEncodingType() {

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -1079,8 +1079,8 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
     private Bitmap getScaledAndRotatedBitmap(byte[] data, String mimeType) throws IOException {
         // If no new width or height were specified, and orientation is not needed return the original bitmap
         Bitmap image = null;
-        try(InputStream imageFileStream = FileHelper.getInputStreamFromUriString(imageUrl, cordova)) {
-            image = BitmapFactory.decodeStream(imageFileStream);
+        try {
+            image = BitmapFactory.decodeStream(new ByteArrayInputStream(data));
         }  catch (OutOfMemoryError e) {
             callbackContext.error(e.getLocalizedMessage());
         } catch (Exception e){

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -768,12 +768,8 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         int quality = (mQuality > 0) ? mQuality : 100;
 
           // PNG ignores quality, just compress once
-        if (encodingType == PNG) {
-            bitmap.compress(compressFormat, mQuality, dataStream);
-            return dataStream.toByteArray();
-        }
-
-        if (maxSizeBytes <= 0) {
+          // Also, if no size limit or max quality, just compress once
+        if (encodingType == PNG || maxSizeBytes <= 0 || quality == 100) {
             bitmap.compress(compressFormat, quality, dataStream);
             return dataStream.toByteArray();
         }
@@ -794,37 +790,11 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
         // Final check after loop in case last attempt meets requirement
         byte[] finalBytes = dataStream.toByteArray();
-        if (finalBytes != null && maxSizeBytes > 0 && finalBytes.length <= maxSizeBytes) {
+        if (finalBytes != null && finalBytes.length <= maxSizeBytes) {
             return finalBytes;
         }
 
         return null;
-    }
-
-    /**
-   * Retrieves the size of the image (or file) pointed to by the given URI.
-   *
-   * <p>This method uses the ContentResolver to query metadata about the file,
-   *
-   * @param uri The {@link android.net.Uri} pointing to the image or file.
-   * @return The size of the file in bytes, or -1 if the size could not be determined
-   *         (e.g., the URI is null, the size column is not available, or an error occurs).
-   */
-     private long getImageSize(Uri uri) {
-        if (uri == null) return -1;
-
-        try (Cursor returnCursor = cordova.getActivity().getContentResolver().query(uri, null, null, null, null)) {
-            if (returnCursor != null && returnCursor.moveToFirst()) {
-                int sizeIndex = returnCursor.getColumnIndex(OpenableColumns.SIZE);
-                if (sizeIndex != -1 && !returnCursor.isNull(sizeIndex)) {
-                    return returnCursor.getLong(sizeIndex);
-                }
-            }
-        } catch (Exception e) {
-            LOG.e("FileSizeCheck", "Error getting file size for URI: " + uri, e);
-        }
-
-        return -1; // Return -1 to indicate failure
     }
 
     /**

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -99,6 +99,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
     private static final String GET_All = "Get All";
     private static final String CROPPED_URI_KEY = "croppedUri";
     private static final String IMAGE_URI_KEY = "imageUri";
+    private static final String IMAGE_SIZE_EXCEEDED_ERROR = "PHOTO_SIZE_EXCEEDS_THE_ALLOWED_LIMIT";
 
     private static final String TAKE_PICTURE_ACTION = "takePicture";
 
@@ -110,6 +111,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
     //Where did this come from?
     private static final int CROP_CAMERA = 100;
+    private long imageSizeLimit;
 
     private static final String TIME_FORMAT = "yyyyMMdd_HHmmss";
 
@@ -171,6 +173,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
             this.allowEdit = args.getBoolean(7);
             this.correctOrientation = args.getBoolean(8);
             this.saveToPhotoAlbum = args.getBoolean(9);
+            this.imageSizeLimit = args.get(12).toString().equals("null") || args.getLong(12) <= 0 ? 0 : args.getLong(12) * 1024 * 1024;
 
             // If the user specifies a 0 or smaller width/height
             // make it -1 so later comparisons succeed
@@ -721,6 +724,31 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         return this.encodingType == JPEG ? JPEG_EXTENSION : PNG_EXTENSION;
     }
 
+    /**
+   * Retrieves the size of the image (or file) pointed to by the given URI.
+   *
+   * <p>This method uses the ContentResolver to query metadata about the file,
+   *
+   * @param uri The {@link android.net.Uri} pointing to the image or file.
+   * @return The size of the file in bytes, or -1 if the size could not be determined
+   *         (e.g., the URI is null, the size column is not available, or an error occurs).
+   */
+     private long getImageSize(Uri uri) {
+        if (uri == null) return -1;
+
+        try (Cursor returnCursor = cordova.getActivity().getContentResolver().query(uri, null, null, null, null)) {
+            if (returnCursor != null && returnCursor.moveToFirst()) {
+                int sizeIndex = returnCursor.getColumnIndex(OpenableColumns.SIZE);
+                if (sizeIndex != -1 && !returnCursor.isNull(sizeIndex)) {
+                    return returnCursor.getLong(sizeIndex);
+                }
+            }
+        } catch (Exception e) {
+            LOG.e("FileSizeCheck", "Error getting file size for URI: " + uri, e);
+        }
+
+        return -1; // Return -1 to indicate failure
+    }
 
     /**
      * Applies all needed transformation to the image received from the gallery.
@@ -730,6 +758,19 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
      */
     private void processResultFromGallery(int destType, Intent intent) {
         Uri uri = intent.getData();
+
+       if(imageSizeLimit > 0) {
+            long imageSize = getImageSize(uri);
+            if (imageSize == -1) {
+                this.failPicture("Unable to retrieve Image Properties");
+                return;
+            }
+            if (imageSize > imageSizeLimit) {
+                this.failPicture(IMAGE_SIZE_EXCEEDED_ERROR);
+                return;
+            }
+        }
+
         if (uri == null) {
             if (croppedUri != null) {
                 uri = croppedUri;
@@ -741,6 +782,9 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
         String uriString = uri.toString();
         String mimeTypeOfGalleryFile = FileHelper.getMimeType(uriString, this.cordova);
+        if(mimeTypeOfGalleryFile.equalsIgnoreCase(PNG_MIME_TYPE)){
+            this.encodingType = PNG;
+        }
         InputStream input;
         try {
             input = cordova.getActivity().getContentResolver().openInputStream(uri);
@@ -1034,15 +1078,16 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
      */
     private Bitmap getScaledAndRotatedBitmap(byte[] data, String mimeType) throws IOException {
         // If no new width or height were specified, and orientation is not needed return the original bitmap
-        if (this.targetWidth <= 0 && this.targetHeight <= 0 && !(this.correctOrientation)) {
-            Bitmap image = null;
-            try {
-                image = BitmapFactory.decodeStream(new ByteArrayInputStream(data));
-            } catch (OutOfMemoryError e) {
-                callbackContext.error(e.getLocalizedMessage());
-            } catch (Exception e) {
-                callbackContext.error(e.getLocalizedMessage());
-            }
+        Bitmap image = null;
+        try(InputStream imageFileStream = FileHelper.getInputStreamFromUriString(imageUrl, cordova)) {
+            image = BitmapFactory.decodeStream(imageFileStream);
+        }  catch (OutOfMemoryError e) {
+            callbackContext.error(e.getLocalizedMessage());
+        } catch (Exception e){
+            callbackContext.error(e.getLocalizedMessage());
+        }
+
+        if ((this.targetWidth <= 0 && this.targetHeight <= 0 && !(this.correctOrientation)) || ((image!=null && image.getWidth() <= this.targetWidth && image.getHeight() <= this.targetHeight))) {
             return image;
         }
 

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -1078,17 +1078,16 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
      */
     private Bitmap getScaledAndRotatedBitmap(byte[] data, String mimeType) throws IOException {
         // If no new width or height were specified, and orientation is not needed return the original bitmap
-        Bitmap image = null;
-        try {
-            image = BitmapFactory.decodeStream(new ByteArrayInputStream(data));
-        }  catch (OutOfMemoryError e) {
-            callbackContext.error(e.getLocalizedMessage());
-        } catch (Exception e){
-            callbackContext.error(e.getLocalizedMessage());
-        }
-
         if ((this.targetWidth <= 0 && this.targetHeight <= 0 && !(this.correctOrientation))) {
-            return image;
+          Bitmap image = null;
+          try {
+              image = BitmapFactory.decodeStream(new ByteArrayInputStream(data));
+          }  catch (OutOfMemoryError e) {
+              callbackContext.error(e.getLocalizedMessage());
+          } catch (Exception e){
+              callbackContext.error(e.getLocalizedMessage());
+          }
+          return image;
         }
 
         int rotate = 0;

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -40,6 +40,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.provider.MediaStore;
+import android.provider.OpenableColumns;
 import androidx.core.content.FileProvider;
 import android.util.Base64;
 import android.system.Os;

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -1087,7 +1087,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
             callbackContext.error(e.getLocalizedMessage());
         }
 
-        if ((this.targetWidth <= 0 && this.targetHeight <= 0 && !(this.correctOrientation)) || ((image!=null && image.getWidth() <= this.targetWidth && image.getHeight() <= this.targetHeight))) {
+        if ((this.targetWidth <= 0 && this.targetHeight <= 0 && !(this.correctOrientation))) {
             return image;
         }
 

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -586,11 +586,6 @@ static NSString* MIME_JPEG    = @"image/jpeg";
     UIImage* scaledImage = nil;
 
     if ((options.targetSize.width > 0) && (options.targetSize.height > 0)) {
-        CGSize imageSize = image.size;
-        if (imageSize.width <= options.targetSize.width && imageSize.height <= options.targetSize.height) {
-            // Image is already smaller than target size, no need to scale
-            return image;
-        }
         // if cropToSize, resize image and crop to target size, otherwise resize to fit target without cropping
         if (options.cropToSize) {
             scaledImage = [image imageByScalingAndCroppingForSize:options.targetSize];

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -440,7 +440,7 @@ static NSString* MIME_JPEG    = @"image/jpeg";
     int attempts = 0;
 
         // Use recursive compression with quality reduction only if size limit is set
-        if (maxSizeBytes > 0) {
+        if (maxSizeBytes > 0 && quality < 1.0f) {
             while (quality > 0.0f && attempts < 3) {
                 data = UIImageJPEGRepresentation(image, quality);
                 // If we're within the limit, return the compressed data

--- a/www/Camera.js
+++ b/www/Camera.js
@@ -142,13 +142,13 @@ cameraExport.getPicture = function (successCallback, errorCallback, options) {
     const saveToPhotoAlbum = !!options.saveToPhotoAlbum;
     const popoverOptions = getValue(options.popoverOptions, null);
     const cameraDirection = getValue(options.cameraDirection, Camera.Direction.BACK);
+    const imageSizeLimit = getValue(options.fileSize);
 
     if (allowEdit) {
         console.warn('allowEdit is deprecated. It does not work reliably on all platforms. Utilise a dedicated image editing library instead. allowEdit functionality is scheduled to be removed in a future release.');
     }
 
-    const args = [quality, destinationType, sourceType, targetWidth, targetHeight, encodingType,
-        mediaType, allowEdit, correctOrientation, saveToPhotoAlbum, popoverOptions, cameraDirection];
+    const args = [quality, destinationType, sourceType, targetWidth, targetHeight, encodingType, mediaType, allowEdit, correctOrientation, saveToPhotoAlbum, popoverOptions, cameraDirection, imageSizeLimit];
 
     exec(successCallback, errorCallback, 'Camera', 'takePicture', args);
     // XXX: commented out


### PR DESCRIPTION
Added logic to compress images up to 3 attempts within the max size limit. If compression still exceeds the limit, return a size-exceeded error.